### PR TITLE
Bugfix: Only close the socket if it's non-null

### DIFF
--- a/Oxide.Ext.Discord/WebSockets/Socket.cs
+++ b/Oxide.Ext.Discord/WebSockets/Socket.cs
@@ -122,11 +122,11 @@ namespace Oxide.Ext.Discord.WebSockets
 
                 if (requested)
                 {
-                    _socket.CloseAsync(4199, "Discord Requested Reconnect");
+                    _socket?.CloseAsync(4199, "Discord Requested Reconnect");
                 }
                 else
                 {
-                    _socket.CloseAsync(CloseStatusCode.Normal);
+                    _socket?.CloseAsync(CloseStatusCode.Normal);
                 }
 
                 DisposeSocket();


### PR DESCRIPTION
Seeing this extension randomly die every few months for some reason. When I reload plugins that depend on it whenever this happens, I get a null pointer in socket disconnect much like this user: https://umod.org/community/discord-chat/48587-error-when-trying-to-load-plugin?page=1

There's no logging or tests so it's hard to tell what's going on, so for now I've added a nullsafe call to at least allow this Disconnect method to complete without throwing an exception.