### PR TITLE
Fix & Cleanup

### DIFF
--- a/Oxide.Ext.Discord/Configuration/DiscordConfig.cs
+++ b/Oxide.Ext.Discord/Configuration/DiscordConfig.cs
@@ -98,7 +98,7 @@ namespace Oxide.Ext.Discord.Configuration
             }
             catch (Exception ex)
             {
-                DiscordExtension.GlobalLogger.Exception("Failed to load config file. Using default config.", ex);
+                Interface.Oxide.LogException($"[Discord Extension] Failed to load config file. Using default config. {ex}", ex);
                 ApplyDefaults();
             }
         }

--- a/Oxide.Ext.Discord/Types/Promises/Promise.cs
+++ b/Oxide.Ext.Discord/Types/Promises/Promise.cs
@@ -483,7 +483,7 @@ namespace Oxide.Ext.Discord.Types
         ///<inheritdoc/>
         public ValueTaskAwaiter GetAwaiter()
         {
-            return _taskSource.GetTask().GetAwaiter();
+            return AsTask().GetAwaiter();
         }
 
         ///<inheritdoc/>

--- a/Oxide.Ext.Discord/Types/Promises/Promise{T}.cs
+++ b/Oxide.Ext.Discord/Types/Promises/Promise{T}.cs
@@ -531,7 +531,7 @@ namespace Oxide.Ext.Discord.Types
         ///<inheritdoc/>
         public ValueTaskAwaiter<TPromised> GetAwaiter()
         {
-            return _taskSource.GetTask().GetAwaiter();
+            return AsTask().GetAwaiter();
         }
 
         ///<inheritdoc/>


### PR DESCRIPTION
Fix trying to log to DiscordExtension logger when config fails to load. Log to oxide instead.