### PR TITLE
3.1.7

### DIFF
--- a/Docs/Generated/Oxide.Ext.Discord/Entities/RequestErrorType.md
+++ b/Docs/Generated/Oxide.Ext.Discord/Entities/RequestErrorType.md
@@ -16,6 +16,7 @@ public enum RequestErrorType : byte
 | ApiError | `ApiError` | An Invalid request was passed to discord |
 | Serialization | `Serialization` | An error occured during JSON serialization |
 | Generic | `Generic` | A non web error occured |
+| Timeout | `Timeout` | A Timeout occured |
 
 ## See Also
 

--- a/Docs/Generated/Oxide.Ext.Discord/Entities/RequestResponse.md
+++ b/Docs/Generated/Oxide.Ext.Discord/Entities/RequestResponse.md
@@ -85,7 +85,7 @@ A web exception [`RequestResponse`](./RequestResponse.md)
 Creates a REST API response for a cancelled request
 
 ```csharp
-public static ValueTask<RequestResponse> CreateCancelledResponse()
+public static RequestResponse CreateCancelledResponse()
 ```
 
 ## Return Value

--- a/Oxide.Ext.Discord/Constants/HttpConstants.cs
+++ b/Oxide.Ext.Discord/Constants/HttpConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace Oxide.Ext.Discord.Constants
+{
+    internal class HttpConstants
+    {
+        public const int Timeout = 30;
+    }
+}

--- a/Oxide.Ext.Discord/Entities/Api/RequestErrorType.cs
+++ b/Oxide.Ext.Discord/Entities/Api/RequestErrorType.cs
@@ -33,6 +33,11 @@ namespace Oxide.Ext.Discord.Entities
         /// <summary>
         /// A non web error occured
         /// </summary>
-        Generic
+        Generic,
+        
+        /// <summary>
+        /// A Timeout occured
+        /// </summary>
+        Timeout
     }
 }

--- a/Oxide.Ext.Discord/Entities/Api/RequestResponse.cs
+++ b/Oxide.Ext.Discord/Entities/Api/RequestResponse.cs
@@ -25,9 +25,7 @@ namespace Oxide.Ext.Discord.Entities
         /// <param name="error">If the request had an error the error created from the request</param>
         private async ValueTask Init(HttpResponseMessage response, RequestCompletedStatus status, ResponseError error = null)
         {
-            Status = status;
-            Error = error;
-
+            Init(status, error);
             if (response != null)
             {
                 Code = (DiscordHttpStatusCode)response.StatusCode;
@@ -37,6 +35,12 @@ namespace Oxide.Ext.Discord.Entities
                 error?.SetResponse(Code, Content);
                 error?.SetRateLimitResponse(RateLimit.Message, RateLimit.Code);
             }
+        }
+
+        private void Init(RequestCompletedStatus status, ResponseError error = null)
+        {
+            Status = status;
+            Error = error;
         }
 
         /// <summary>
@@ -69,10 +73,10 @@ namespace Oxide.Ext.Discord.Entities
         /// Creates a REST API response for a cancelled request
         /// </summary>
         /// <returns>A cancelled <see cref="RequestResponse"/></returns>
-        public static async ValueTask<RequestResponse> CreateCancelledResponse()
+        public static RequestResponse CreateCancelledResponse()
         {
             RequestResponse response = DiscordPool.Internal.Get<RequestResponse>();
-            await response.Init(null, RequestCompletedStatus.Cancelled).ConfigureAwait(false);
+            response.Init(RequestCompletedStatus.Cancelled);
             return response;
         }
 

--- a/Oxide.Ext.Discord/Entities/Api/ResponseError.cs
+++ b/Oxide.Ext.Discord/Entities/Api/ResponseError.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using Oxide.Core.Libraries;
 using Oxide.Ext.Discord.Clients;
 using Oxide.Ext.Discord.Configuration;
+using Oxide.Ext.Discord.Constants;
 using Oxide.Ext.Discord.Exceptions;
 using Oxide.Ext.Discord.Extensions;
 using Oxide.Ext.Discord.Logging;
@@ -214,6 +215,10 @@ namespace Oxide.Ext.Discord.Entities
 
                 case RequestErrorType.GenericWeb:
                     _client.Logger.Error("Rest Request Exception (Web Error). Plugin: {0} ID: {1} Request URL: [{2}] {3} Content-Type: {4} Http Response Code: {5} Message: {6}", _client.PluginName, RequestId, RequestMethod, Url, ContentType, HttpStatusCode, ResponseMessage);
+                    break;
+                
+                case RequestErrorType.Timeout:
+                    _client.Logger.Error("Rest Request Exception (Timeout). Plugin: {0} ID: {1} Request URL: [{2}] {3} Took longer than {4} seconds to complete the request", _client.PluginName, RequestId, RequestMethod, Url, HttpConstants.Timeout);
                     break;
 
                 case RequestErrorType.Serialization:

--- a/Oxide.Ext.Discord/Oxide.Ext.Discord.xml
+++ b/Oxide.Ext.Discord/Oxide.Ext.Discord.xml
@@ -4653,6 +4653,11 @@
             A non web error occured
             </summary>
         </member>
+        <member name="F:Oxide.Ext.Discord.Entities.RequestErrorType.Timeout">
+            <summary>
+            A Timeout occured
+            </summary>
+        </member>
         <member name="T:Oxide.Ext.Discord.Entities.RequestResponse">
             <summary>
             Represents a REST response from discord

--- a/Oxide.Ext.Discord/Rest/Buckets/Bucket.cs
+++ b/Oxide.Ext.Discord/Rest/Buckets/Bucket.cs
@@ -183,7 +183,7 @@ namespace Oxide.Ext.Discord.Rest
                         continue;
                     }
 
-                    if (Remaining < 0)
+                    if (Remaining < 0 && IsKnownBucket)
                     {
                         _logger.Debug($"{nameof(Bucket)}.{nameof(WaitUntilBucketAvailable)} Plugin: {{0}} Bucket ID: {{1}} Request ID: {{2}} Can't Start Request Due to Remaining < 0: {{3}} Url: {{4}} Limit: {{5}} Remaining: {{6}} Waiting For: {{7}} Seconds", client.PluginName, Id, request.Id, request.Method, request.Route, Limit, Remaining, (ResetAt - DateTimeOffset.UtcNow).TotalSeconds);
                         await ResetAt.DelayUntil(100, token).ConfigureAwait(false);

--- a/Oxide.Ext.Discord/Rest/Requests/BaseRequest.cs
+++ b/Oxide.Ext.Discord/Rest/Requests/BaseRequest.cs
@@ -144,6 +144,7 @@ namespace Oxide.Ext.Discord.Rest
         {
             if (!Source.IsCancellationRequested)
             {
+                Client.Logger.Debug($"{nameof(BaseRequest)}.{nameof(Abort)} Aborting Request Request ID: {{0}} Plugin: {{1}} Method: {{2}} Route: {{3}}", Id, Client.PluginName, Method, Route);
                 Source.Cancel();
                 Status = RequestStatus.Cancelled;
             }

--- a/Oxide.Ext.Discord/Rest/RestHandler.cs
+++ b/Oxide.Ext.Discord/Rest/RestHandler.cs
@@ -61,7 +61,7 @@ namespace Oxide.Ext.Discord.Rest
             };
             Client = new HttpClient(handler)
             {
-                Timeout = TimeSpan.FromSeconds(15),
+                Timeout = TimeSpan.FromSeconds(HttpConstants.Timeout),
                 BaseAddress = new Uri(DiscordEndpoints.Rest.ApiUrl)
             };
             Client.DefaultRequestHeaders.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));

--- a/Oxide.Ext.Discord/WebSockets/Handlers/WebSocketCommandHandler.cs
+++ b/Oxide.Ext.Discord/WebSockets/Handlers/WebSocketCommandHandler.cs
@@ -153,6 +153,13 @@ namespace Oxide.Ext.Discord.WebSockets
         /// <param name="command">Command to send over the websocket</param>
         public void Enqueue(WebSocketCommand command)
         {
+            if (!_isSocketReady && command.Payload.OpCode == GatewayCommandCode.PresenceUpdate)
+            {
+                _logger.Debug($"{nameof(WebSocketCommandHandler)}.{nameof(Enqueue)} {{0}} Skipping command {{1}}. Websocket is not ready", command.Client.PluginName, command.Payload.OpCode);
+                command.Dispose();
+                return;
+            }
+            
             _logger.Debug($"{nameof(WebSocketCommandHandler)}.{nameof(Enqueue)} {{0}} Queuing command {{1}}", command.Client.PluginName, command.Payload.OpCode);
             _pendingCommands.Enqueue(command);
             _commands.Set();

--- a/Oxide.Ext.Discord/WebSockets/Handlers/WebsocketEventHandler.cs
+++ b/Oxide.Ext.Discord/WebSockets/Handlers/WebsocketEventHandler.cs
@@ -617,7 +617,7 @@ namespace Oxide.Ext.Discord.WebSockets
             _webSocket.OnSocketReady(ready);
             _client.OnClientReady(ready);
 
-            _logger.Info("Your bot was found in {0} Guilds!", ready.Guilds.Count);
+            _logger.Info("Your bot {0} was found in {1} Guilds!", ready.User.Username, ready.Guilds.Count);
         }
 
         private IPromise<DiscordApplication> ProcessGatewayIntents(DiscordApplication app)


### PR DESCRIPTION
- Increased timeout duration to 30 seconds.
- Fixed improper handling of timeouts causing the request to be canceled.
- Fixed requests getting stuck permanently if we never had a successful first request for a bucket.
- Don't enqueue PresenceUpdate commands when the socket is not connected.
- Log the bot name that connected